### PR TITLE
Remove paragraph spaces

### DIFF
--- a/src/parsers.js
+++ b/src/parsers.js
@@ -2,7 +2,7 @@ import { sanitizeHtml } from "./utitlities";
 
 export default {
     paragraph: function(data, config) {
-        return `<p class="${config.paragraph.pClass}"> ${data.text} </p>`;
+        return `<p class="${config.paragraph.pClass}">${data.text}</p>`;
     },
 
     header: function(data) {


### PR DESCRIPTION
These spaces causes the paragraphs to increase in length if you feed the result of the parse back into the editor. Removing it doesnt change anything in UI, it will only solve the problem.